### PR TITLE
Skip workflow_dispatch runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ To try out this branch on [binder](https://mybinder.org), follow this link: [![B
 
     if (event_type === "workflow_dispatch") {
       console.log('\n--------------------------------');
-      console.log('Skipping workflow_dispatch run');
+      console.log('Ignoring workflow_dispatch run');
       console.log('--------------------------------\n');
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,12 @@ To try out this branch on [binder](https://mybinder.org), follow this link: [![B
     const duplicates: RunData[] = [];
     const messages: string[] = [];
 
+    if (event_type === "workflow_dispatch") {
+      console.log('\n--------------------------------');
+      console.log('Skipping workflow_dispatch run');
+      console.log('--------------------------------\n');
+    }
+
     if (process.env.DEBUG == 'true') {
       fs.writeFileSync("outputs.txt", "\n\n" + JSON.stringify(context.payload) + "\n", { flag: "a" });
     }


### PR DESCRIPTION
Fixes #8.  There is no `input` information in the event, so just do not cancel workflow_dispatch runs.