### PR TITLE
Add needs triage label to new issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Example:
 ```yaml
 addBinderLink: true
 binderUrlSuffix: "?urlpath=lab-dev"
+triageLabel: "status:Needs Triage"
 ```
 
 ## Deploying

--- a/schema.json
+++ b/schema.json
@@ -11,6 +11,11 @@
       "title": "Binder URL Suffix",
       "description": "Suffix for Binder URL",
       "type": "string"
+    },
+    "triageLabel": {
+      "title": "Triage label",
+      "description": "Triage label to apply on newly opened issues",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,11 @@ export = (app: Probot) => {
     const config = await getConfig(context);
     const triageLabel = config['triageLabel'] ?? 'status:Needs Triage';
 
-    await context.octokit.issues.addLabels(context.issue({ labels: [triageLabel] }))
+    if (!(issue.labels ?? []).map((label) => label.name).includes(triageLabel)) {
+      await context.octokit.issues.addLabels(
+        context.issue({ labels: [triageLabel] })
+      );
+    }
   });
 
   app.on('pull_request.opened', async (context) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 
-import Ajv, {JSONSchemaType} from 'ajv';
+import Ajv, { JSONSchemaType } from 'ajv';
 
 import * as fs from 'fs';
 
-import { Context, Probot} from "probot";
+import { Context, Probot } from "probot";
 
 
 /**
@@ -20,6 +20,7 @@ interface RunData {
 interface Config {
   binderUrlSuffix?: string;
   addBinderLink?: boolean;
+  triageLabel?: string;
 }
 
 
@@ -47,6 +48,19 @@ async function getConfig(context: Context<any>): Promise<Config> {
 
 
 export = (app: Probot) => {
+
+  /**
+   * Add triage label to opened issues
+   */
+  app.on('issues.opened', async (context) => {
+    const { payload } = context;
+    const { issue } = payload;
+
+    const config = await getConfig(context);
+    const triageLabel = config['triageLabel'] ?? 'status:Needs Triage';
+
+    await context.octokit.issues.addLabels(context.issue({ labels: [triageLabel] }))
+  });
 
   app.on('pull_request.opened', async (context) => {
     const head = context.payload.pull_request.head;
@@ -106,7 +120,7 @@ To try out this branch on [binder](https://mybinder.org), follow this link: [![B
       fs.writeFileSync("outputs.txt", "\n\n" + JSON.stringify(context.payload) + "\n", { flag: "a" });
     }
 
-    const statuses =  ["queued", "in_progress", "requested"];
+    const statuses = ["queued", "in_progress", "requested"];
     await Promise.all(statuses.map(async (status) => {
       const resp = await context.octokit.rest.actions.listWorkflowRuns({
         owner,

--- a/test/fixtures/issue_labelled.opened.json
+++ b/test/fixtures/issue_labelled.opened.json
@@ -1,0 +1,34 @@
+{
+    "action": "opened",
+    "issue": {
+      "number": 42,
+      "title": "Spelling error in the README file",
+      "user": {
+        "login": "hiimbex"
+      },
+      "labels": [
+        {
+          "id": 1362934389,
+          "node_id": "MDU6TGFiZWwxMzYyOTM0Mzg5",
+          "name": "status:Needs Triage",
+          "color": "d73a4a",
+          "default": true
+        }
+      ],
+      "state": "open",
+      "locked": false,
+      "comments": 0,
+      "created_at": "2019-05-15T15:20:18Z",
+      "updated_at": "2019-05-15T15:20:18Z",
+      "closed_at": null,
+      "author_association": "OWNER",
+      "body": "It looks like you accidently spelled 'commit' with two 't's."
+    },
+    "changes": {},
+    "repository": {
+      "name": "testing-things",
+      "owner": {
+        "login": "hiimbex"
+      }
+    }
+  }

--- a/test/fixtures/issue_labelled.opened.json
+++ b/test/fixtures/issue_labelled.opened.json
@@ -1,34 +1,34 @@
 {
-    "action": "opened",
-    "issue": {
-      "number": 42,
-      "title": "Spelling error in the README file",
-      "user": {
-        "login": "hiimbex"
-      },
-      "labels": [
-        {
-          "id": 1362934389,
-          "node_id": "MDU6TGFiZWwxMzYyOTM0Mzg5",
-          "name": "status:Needs Triage",
-          "color": "d73a4a",
-          "default": true
-        }
-      ],
-      "state": "open",
-      "locked": false,
-      "comments": 0,
-      "created_at": "2019-05-15T15:20:18Z",
-      "updated_at": "2019-05-15T15:20:18Z",
-      "closed_at": null,
-      "author_association": "OWNER",
-      "body": "It looks like you accidently spelled 'commit' with two 't's."
+  "action": "opened",
+  "issue": {
+    "number": 42,
+    "title": "Spelling error in the README file",
+    "user": {
+      "login": "hiimbex"
     },
-    "changes": {},
-    "repository": {
-      "name": "testing-things",
-      "owner": {
-        "login": "hiimbex"
+    "labels": [
+      {
+        "id": 1362934389,
+        "node_id": "MDU6TGFiZWwxMzYyOTM0Mzg5",
+        "name": "status:Needs Triage",
+        "color": "d73a4a",
+        "default": true
       }
+    ],
+    "state": "open",
+    "locked": false,
+    "comments": 0,
+    "created_at": "2019-05-15T15:20:18Z",
+    "updated_at": "2019-05-15T15:20:18Z",
+    "closed_at": null,
+    "author_association": "OWNER",
+    "body": "It looks like you accidently spelled 'commit' with two 't's."
+  },
+  "changes": {},
+  "repository": {
+    "name": "testing-things",
+    "owner": {
+      "login": "hiimbex"
     }
   }
+}

--- a/test/fixtures/issue_no_label.opened.json
+++ b/test/fixtures/issue_no_label.opened.json
@@ -1,0 +1,25 @@
+{
+  "action": "opened",
+  "issue": {
+    "number": 42,
+    "title": "Spelling error in the README file",
+    "user": {
+      "login": "hiimbex"
+    },
+    "state": "open",
+    "locked": false,
+    "comments": 0,
+    "created_at": "2019-05-15T15:20:18Z",
+    "updated_at": "2019-05-15T15:20:18Z",
+    "closed_at": null,
+    "author_association": "OWNER",
+    "body": "It looks like you accidently spelled 'commit' with two 't's."
+  },
+  "changes": {},
+  "repository": {
+    "name": "testing-things",
+    "owner": {
+      "login": "hiimbex"
+    }
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -41,14 +41,6 @@ describe("My Probot app", () => {
     const configBuffer = Buffer.from(JSON.stringify(config));
 
     const mock = nock("https://api.github.com")
-      .persist()
-      .post("/app/installations/2/access_tokens")
-      .reply(200, {
-        token: "test",
-        permissions: {
-          actions: "write"
-        },
-      })
 
     .get("/repos/hiimbex/testing-things/contents/.github%2Fjupyterlab-probot.yml")
     .reply(200, configBuffer.toString())
@@ -57,7 +49,7 @@ describe("My Probot app", () => {
     .reply(200);
 
     // Receive a webhook event
-    await probot.receive({ name: "issue", payload: openedIssueNoLabel });
+    await probot.receive({ name: "issues", payload: openedIssueNoLabel });
 
     expect(mock.pendingMocks()).toStrictEqual([]);
   });
@@ -68,23 +60,12 @@ describe("My Probot app", () => {
     const configBuffer = Buffer.from(JSON.stringify(config));
 
     const mock = nock("https://api.github.com")
-      .persist()
-      .post("/app/installations/2/access_tokens")
-      .reply(200, {
-        token: "test",
-        permissions: {
-          actions: "write"
-        },
-      })
 
     .get("/repos/hiimbex/testing-things/contents/.github%2Fjupyterlab-probot.yml")
-    .reply(200, configBuffer.toString())
-
-    .post("/repos/hiimbex/testing-things/issues/42/labels")
-    .reply(200);
+    .reply(200, configBuffer.toString());
 
     // Receive a webhook event
-    await probot.receive({ name: "issue", payload: openedIssue });
+    await probot.receive({ name: "issues", payload: openedIssue });
 
     expect(mock.pendingMocks()).toStrictEqual([]);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,6 +6,8 @@ import { Probot, ProbotOctokit } from "probot";
 import duplicatePushes from './fixtures/duplicate_pushes.json';
 import duplicatePRs from './fixtures/duplicate_pull_requests.json';
 import openPREvent from './fixtures/pull_request.opened.json';
+import openedIssueNoLabel from './fixtures/issue_no_label.opened.json';
+import openedIssue from './fixtures/issue_labelled.opened.json';
 
 const fs = require("fs");
 const path = require("path");
@@ -31,6 +33,60 @@ describe("My Probot app", () => {
     });
     // Load our app into probot
     probot.load(myProbotApp);
+  });
+
+  test('add triage label to opened issue', async () => {
+
+    const config = {};
+    const configBuffer = Buffer.from(JSON.stringify(config));
+
+    const mock = nock("https://api.github.com")
+      .persist()
+      .post("/app/installations/2/access_tokens")
+      .reply(200, {
+        token: "test",
+        permissions: {
+          actions: "write"
+        },
+      })
+
+    .get("/repos/hiimbex/testing-things/contents/.github%2Fjupyterlab-probot.yml")
+    .reply(200, configBuffer.toString())
+
+    .post("/repos/hiimbex/testing-things/issues/42/labels")
+    .reply(200);
+
+    // Receive a webhook event
+    await probot.receive({ name: "issue", payload: openedIssueNoLabel });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+
+  test('does not add triage label to opened issue that have it already', async () => {
+
+    const config = {};
+    const configBuffer = Buffer.from(JSON.stringify(config));
+
+    const mock = nock("https://api.github.com")
+      .persist()
+      .post("/app/installations/2/access_tokens")
+      .reply(200, {
+        token: "test",
+        permissions: {
+          actions: "write"
+        },
+      })
+
+    .get("/repos/hiimbex/testing-things/contents/.github%2Fjupyterlab-probot.yml")
+    .reply(200, configBuffer.toString())
+
+    .post("/repos/hiimbex/testing-things/issues/42/labels")
+    .reply(200);
+
+    // Receive a webhook event
+    await probot.receive({ name: "issue", payload: openedIssue });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
   });
 
   test('does not create a comment with a binder link', async () => {


### PR DESCRIPTION
To add the triage label to all issues (even those not created from the template), I propose to add a event action on the bot.

cc @jweill-aws