### PR TITLE
Removes default value, aborts labeling if no triageLabel specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,14 +50,18 @@ async function getConfig(context: Context<any>): Promise<Config> {
 export = (app: Probot) => {
 
   /**
-   * Add triage label to opened issues
+   * Add triage label to opened issues, if one is specified
    */
   app.on('issues.opened', async (context) => {
     const { payload } = context;
     const { issue } = payload;
 
     const config = await getConfig(context);
-    const triageLabel = config['triageLabel'] ?? 'status:Needs Triage';
+    const triageLabel = config['triageLabel'];
+
+    if (triageLabel === undefined) {
+      return;
+    }
 
     if (!(issue.labels ?? []).map((label) => label.name).includes(triageLabel)) {
       await context.octokit.issues.addLabels(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -37,7 +37,9 @@ describe("My Probot app", () => {
 
   test('add triage label to opened issue', async () => {
 
-    const config = {};
+    const config = {
+      triageLabel: 'status:Needs Triage'
+    };
     const configBuffer = Buffer.from(JSON.stringify(config));
 
     const mock = nock("https://api.github.com")
@@ -54,9 +56,11 @@ describe("My Probot app", () => {
     expect(mock.pendingMocks()).toStrictEqual([]);
   });
 
-  test('does not add triage label to opened issue that have it already', async () => {
+  test('does not add triage label to opened issue that has it already', async () => {
 
-    const config = {};
+    const config = {
+      triageLabel: 'status:Needs Triage'
+    };
     const configBuffer = Buffer.from(JSON.stringify(config));
 
     const mock = nock("https://api.github.com")

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -56,6 +56,22 @@ describe("My Probot app", () => {
     expect(mock.pendingMocks()).toStrictEqual([]);
   });
 
+  test('does not add triage label when config lacks triageLabel', async () => {
+
+    const config = {};
+    const configBuffer = Buffer.from(JSON.stringify(config));
+
+    const mock = nock("https://api.github.com")
+
+    .get("/repos/hiimbex/testing-things/contents/.github%2Fjupyterlab-probot.yml")
+    .reply(200, configBuffer.toString());
+
+    // Receive a webhook event
+    await probot.receive({ name: "issues", payload: openedIssueNoLabel });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+
   test('does not add triage label to opened issue that has it already', async () => {
 
     const config = {


### PR DESCRIPTION
This change addresses #12. This change removes the default value for `triageLabel`, only applying the triage label if it is specified.