### PR TITLE
No workflow cancellation if event is `issue_comment`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,9 +117,9 @@ To try out this branch on [binder](https://mybinder.org), follow this link: [![B
     const duplicates: RunData[] = [];
     const messages: string[] = [];
 
-    if (event_type === "workflow_dispatch") {
+    if (["issue_comment", "workflow_dispatch"].includes(event_type)) {
       console.log('\n--------------------------------');
-      console.log('Ignoring workflow_dispatch run');
+      console.log(`Ignoring ${event_type} run`);
       console.log('--------------------------------\n');
       return;
     }


### PR DESCRIPTION
Seen in jupyterlab/jupyterlab

As soon as a comment on any PR is added, workflows generated from `issue_comment` get cancelled even if the comment comes from another PR (and it will also happen if the comment comes from the same PR whatever its content). So for now skip looking for duplicated workflow if the event is an issue comment.

Example of unwanted workflow cancellation: https://github.com/jupyterlab/jupyterlab/actions/runs/1952374323