### PR TITLE
Stop canceling enforce label runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,18 @@ To try out this branch on [binder](https://mybinder.org), follow this link: [![B
       return;
     }
 
+    const resp = await context.octokit.rest.actions.getWorkflow({
+      owner,
+      repo,
+      workflow_id
+    });
+    if (resp.data.path.indexOf('enforce-label') != -1) {
+      console.log('\n--------------------------------');
+      console.log('Ignore enforce label run');
+      console.log('--------------------------------\n');
+      return;
+    }
+
     if (process.env.DEBUG == 'true') {
       fs.writeFileSync("outputs.txt", "\n\n" + JSON.stringify(context.payload) + "\n", { flag: "a" });
     }

--- a/test/fixtures/workflow_data.json
+++ b/test/fixtures/workflow_data.json
@@ -1,0 +1,12 @@
+{
+  "id": 161335,
+  "node_id": "MDg6V29ya2Zsb3cxNjEzMzU=",
+  "name": "CI",
+  "path": ".github/workflows/blank.yaml",
+  "state": "active",
+  "created_at": "2020-01-08T23:48:37.000-08:00",
+  "updated_at": "2020-01-08T23:50:21.000-08:00",
+  "url": "https://api.github.com/repos/octo-org/octo-repo/actions/workflows/161335",
+  "html_url": "https://github.com/octo-org/octo-repo/blob/master/.github/workflows/161335",
+  "badge_url": "https://github.com/octo-org/octo-repo/workflows/CI/badge.svg"
+}


### PR DESCRIPTION
We had a race condition on Enforce Label runs because they run when the PR is labeled, which can happen before the initial run has occurred.  Each of these events sees the other as a duplicate and they end up killing each other.  Tragic!