### PR TITLE
Check created_at when canceling runs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,11 +148,17 @@ To try out this branch on [binder](https://mybinder.org), follow this link: [![B
       }
       let runs = resp.data.workflow_runs.map(run => {
         return {
-          id: run.id
+          id: run.id,
+          created_at: Date.parse(run.created_at)
         }
       });
       // Make sure the triggered run is not listed
-      runs = runs.filter(data => data.id !== run.id);
+      runs = runs.filter(data => {
+        if (data.id === run.id) {
+          return false;
+        }
+        return Date.parse(run.created_at) > data.created_at;
+      });
       duplicates.push(...runs);
     }));
 

--- a/test/fixtures/duplicate_pull_requests.json
+++ b/test/fixtures/duplicate_pull_requests.json
@@ -29,7 +29,7 @@
         "event":"pull_request",
         "status":"queued",
         "workflow_id":8439041,
-        "created_at":"2021-08-29T10:12:37Z"
+        "created_at":"2021-08-29T10:12:59Z"
       }
     ]
   },

--- a/test/fixtures/duplicate_pushes.json
+++ b/test/fixtures/duplicate_pushes.json
@@ -2,13 +2,13 @@
   "event":{
     "action":"requested",
     "workflow_run":{
-      "id":1179077687,
+      "id":1179077689,
       "name":"Check Release",
       "event":"push",
       "status":"queued",
       "workflow_id":8438617,
       "head_branch":"hiimbex-patch-2",
-      "created_at":"2021-08-29T10:12:55Z"
+      "created_at":"2021-08-29T10:12:54Z"
     },
     "repository":{
       "owner":{

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -193,7 +193,6 @@ describe("My Probot app", () => {
       .post("/repos/hiimbex/testing-things/actions/runs/1179077215/cancel")
       .reply(202, {})
 
-
     // Receive a webhook event
     await probot.receive({ name: "workflow_run", payload: duplicatePushes.event });
 
@@ -222,9 +221,6 @@ describe("My Probot app", () => {
       .reply(200, duplicatePRs.in_progress_response)
 
       .post("/repos/hiimbex/testing-things/actions/runs/1179072529/cancel")
-      .reply(202, {})
-
-      .post("/repos/hiimbex/testing-things/actions/runs/1179077219/cancel")
       .reply(202, {});
 
     // Receive a webhook event


### PR DESCRIPTION
Avoids a race condition where workflows can cancel each other.